### PR TITLE
updated peacemaker tests

### DIFF
--- a/test/fixtures/responses.ts
+++ b/test/fixtures/responses.ts
@@ -593,49 +593,38 @@ export const THE_PEACEMAKER_01_1967_PARSED_YML = {
   artists: [],
   artwork_md5: null,
   description:
-    'The fleets of various foreign countries, that have been fishing near maritime borders of other countries, have recently become the target of sabotage and have began blaming each other for it. U.S. Diplomat Christopher Smith heads to a fishing trawler named the "Manson", where its Captain welcomes him and takes him to their oceanographer Mr. Boyle. Boyle tells Smith that the fishing fleets follow predictable paths, but they are being attacked by a mysterious force, while American fishermen also claim that the fish are being diverted to other waters by someone. The Captain tells Smith that the entity responsible isn\'t related to any country and the recent acts of sabotage have taken place on the Thousand Mile Reef.\n\nAs the Manson lowers its fishing nets after arriving at the reef, a frogman saboteur is ordered by his master to destroy the nets by using tiny explosives. He does so and attaches an explosive charge to the Manson\'s hull. Telling the crew of the trawler that he did it on orders of the Commodore, he warns them that they only have a minute to save themselves. Smith learns from the captain that this "Commodore" is the one behind acts of sabotage on ships and soon dons his Peacemaker uniform. Jumping into the water, he quickly disables the charge, but is attacked by a group of sharks on the frogman\'s orders. He successfully flees using his jetpack, which can also function in water, and leaves the activated charge among the sharks.\n\nAs the sharks get caught in the blast, the frogman flees and Smith pursues him; successfully guessing he\'s heading to a nuclear submarine. Peacemaker overhears the frogman ordering his comrades on radio to shut the entrance the moment he is inside, and knocks him out. As he investigates the submarine, its crewmen realize he is not their shipmate Claude, who had been sent outside, and inform the Commodore. The Commodore orders Peacemaker to be brought before him. Smith confirms his suspicions that he prevented him from sabotaging the Manson. When the Commodore mocks him for not saving the explosive charge for his crew, Smith states that he already has hidden explosives which they can never find and asks him to explain why he has been attacking the fleets.\n\nThe Commodore soon reveals himself to be insane, claiming that all the seas are his domain and other men are trying to invade it, but it his duty to protect all sea-life. Smith destroys the nuclear reactor engine of the sub before the Commodore can kill him and tells the crew to stand by the entrance hatch as he makes the sub surface above water. The crew successfully escapes before it explodes and are apprehended by the men of the Manson, while the Commodore starts cursing Smith. While rambling, he reveals that he was going to leave for Antarctica and link up with his partners who would help him conquer the world. Days later in Switzerland, Smith ponders who the Commodore was referring to while heading back to his private ch\u00E2teau.\n',
+    'Diplomat Christopher Smith battles the Commodore, a villain who operates from a nuclear submarine and threatens international fishing fleets in an attempt to claim the riches of the sea. In a second story, the Peacemaker confronts a small Balkan nation that has secretly built nuclear facilities in Antarctica and threatens the world with destruction. The issue also features a Fightin\' 5 backup story continuing from Fightin\' Five #41, in which the team faces a deadly mission that costs the life of one of their own, Irv the Nerve Haganah.\n',
   duration: null,
-  info_url: 'https://dc.fandom.com/wiki/Peacemaker_Vol_1_1',
+  info_url: 'https://www.comics.org/issue/20786/',
   metadata_list: [
+    {writer: 'Joe Gill'},
+    {penciller: 'Pat Boyette'},
+    {inker: 'Pat Boyette'},
+    {letterer: 'Pat Boyette'},
+    {penciller: 'Bill Montes'},
+    {inker: 'Ernie Bache'},
+    {editor: 'Dick Giordano'},
+    {'cover artist': 'Pat Boyette'},
+    {publisher: 'Charlton Comics'},
+    {genre: 'Superhero'},
+    {franchise: 'The Peacemaker'},
+    {universe: 'DC Prime Earth'},
+    {character: 'Peacemaker (Christopher Smith)'},
+    {character: 'Peacemaker'},
+    {character: "Fightin' 5"},
+    {character: 'The Commodore'},
+    {tag: 'silver age'},
+    {tag: 'charlton comics'},
+    {tag: 'cold war'},
+    {'ai:rating': 2},
     {
-      character: 'Christopher Smith',
+      'ai:rating_reasoning':
+        "The Peacemaker #1 (1967) is a historically noteworthy Silver Age single issue from Charlton Comics as the first issue of Peacemaker's solo series, but the original run was commercially unsuccessful, lasting only five issues before cancellation. The character fell into obscurity for decades (per Wikipedia and DC.com retrospectives) and the series has received no award recognition. The primary historical significance lies in the character later inspiring The Comedian in Alan Moore's Watchmen. Charlton was widely regarded as a budget publisher. The issue has collector value but limited critical merit by modern standards.",
     },
-    {
-      character: 'Peacemaker',
-    },
-    {
-      cover_artist: 'Pat Boyette',
-    },
-    {
-      inker: 'Pat Boyette',
-    },
-    {
-      letterer: 'Pat Boyette',
-    },
-    {
-      penciler: 'Pat Boyette',
-    },
-    {
-      publisher: 'Charlton Comics',
-    },
-    {
-      publisher: 'DC Comics',
-    },
-    {
-      tag: 'Peacemaker',
-    },
-    {
-      synopsis:
-        'The Commodore has been damaging fishing fleets, but the Peacemaker captures him and destroys his submarine',
-    },
-    {
-      writer: 'Joe Gill',
-    },
-    {
-      source_url: 'https://comicbookplus.com/?dlid=70555',
-    },
+    {'ai:skill_version': '7.16.4'},
+    {'ai:engine': 'claude-opus-4-6'},
   ],
-  name: 'The Peacemaker',
+  name: 'The Peacemaker #01',
   path_to_file: 'test/fixtures/samples/comics/The_Peacemaker_01_1967.eivu_compressed.cbz',
   rating: null,
   release: EMPTY_RELEASE,
@@ -662,7 +651,7 @@ export const THE_PEACEMAKER_01_1967_COVER_ART_DATA_PROFILE = {
   duration: null,
   info_url: null,
   metadata_list: [],
-  name: 'Cover Art for The Peacemaker',
+  name: 'Cover Art for The Peacemaker #01',
   path_to_file: '/tmp/coverart-extractedByEivu-forComic-The_Peacemaker_01_1967.eivu_compressed-COVERART.webp',
   rating: null,
   release: EMPTY_RELEASE,
@@ -726,7 +715,7 @@ export const THE_PEACEMAKER_01_1967_COVER_ART_TRANSFER: CloudFileType = {
 export const THE_PEACEMAKER_01_1967_COVER_ART_COMPLETE: CloudFileType = {
   ...THE_PEACEMAKER_01_1967_COVER_ART_TRANSFER,
   metadata: [],
-  name: 'Cover Art for The Peacemaker',
+  name: 'Cover Art for The Peacemaker #01',
   state: CloudFileState.COMPLETED,
 }
 

--- a/test/fixtures/samples/comics/The_Peacemaker_01_1967.eivu_compressed.cbz.eivu.yml
+++ b/test/fixtures/samples/comics/The_Peacemaker_01_1967.eivu_compressed.cbz.eivu.yml
@@ -1,24 +1,29 @@
+name: "The Peacemaker #01"
+year: 1967
 description: |
-  The fleets of various foreign countries, that have been fishing near maritime borders of other countries, have recently become the target of sabotage and have began blaming each other for it. U.S. Diplomat Christopher Smith heads to a fishing trawler named the "Manson", where its Captain welcomes him and takes him to their oceanographer Mr. Boyle. Boyle tells Smith that the fishing fleets follow predictable paths, but they are being attacked by a mysterious force, while American fishermen also claim that the fish are being diverted to other waters by someone. The Captain tells Smith that the entity responsible isn't related to any country and the recent acts of sabotage have taken place on the Thousand Mile Reef.
-  
-  As the Manson lowers its fishing nets after arriving at the reef, a frogman saboteur is ordered by his master to destroy the nets by using tiny explosives. He does so and attaches an explosive charge to the Manson's hull. Telling the crew of the trawler that he did it on orders of the Commodore, he warns them that they only have a minute to save themselves. Smith learns from the captain that this "Commodore" is the one behind acts of sabotage on ships and soon dons his Peacemaker uniform. Jumping into the water, he quickly disables the charge, but is attacked by a group of sharks on the frogman's orders. He successfully flees using his jetpack, which can also function in water, and leaves the activated charge among the sharks.
-  
-  As the sharks get caught in the blast, the frogman flees and Smith pursues him; successfully guessing he's heading to a nuclear submarine. Peacemaker overhears the frogman ordering his comrades on radio to shut the entrance the moment he is inside, and knocks him out. As he investigates the submarine, its crewmen realize he is not their shipmate Claude, who had been sent outside, and inform the Commodore. The Commodore orders Peacemaker to be brought before him. Smith confirms his suspicions that he prevented him from sabotaging the Manson. When the Commodore mocks him for not saving the explosive charge for his crew, Smith states that he already has hidden explosives which they can never find and asks him to explain why he has been attacking the fleets.
-  
-  The Commodore soon reveals himself to be insane, claiming that all the seas are his domain and other men are trying to invade it, but it his duty to protect all sea-life. Smith destroys the nuclear reactor engine of the sub before the Commodore can kill him and tells the crew to stand by the entrance hatch as he makes the sub surface above water. The crew successfully escapes before it explodes and are apprehended by the men of the Manson, while the Commodore starts cursing Smith. While rambling, he reveals that he was going to leave for Antarctica and link up with his partners who would help him conquer the world. Days later in Switzerland, Smith ponders who the Commodore was referring to while heading back to his private château.
-info_url: https://dc.fandom.com/wiki/Peacemaker_Vol_1_1
+  Diplomat Christopher Smith battles the Commodore, a villain who operates from a nuclear submarine and threatens international fishing fleets in an attempt to claim the riches of the sea. In a second story, the Peacemaker confronts a small Balkan nation that has secretly built nuclear facilities in Antarctica and threatens the world with destruction. The issue also features a Fightin' 5 backup story continuing from Fightin' Five #41, in which the team faces a deadly mission that costs the life of one of their own, Irv the Nerve Haganah.
+info_url: https://www.comics.org/issue/20786/
 metadata_list:
-  - character: Christopher Smith
-  - character: Peacemaker
-  - cover_artist: Pat Boyette
+  - writer: Joe Gill
+  - penciller: Pat Boyette
   - inker: Pat Boyette
   - letterer: Pat Boyette
-  - penciler: Pat Boyette
+  - penciller: Bill Montes
+  - inker: Ernie Bache
+  - editor: Dick Giordano
+  - cover artist: Pat Boyette
   - publisher: Charlton Comics
-  - publisher: DC Comics
-  - tag: Peacemaker
-  - synopsis: The Commodore has been damaging fishing fleets, but the Peacemaker captures him and destroys his submarine
-  - writer: Joe Gill
-  - source_url: https://comicbookplus.com/?dlid=70555
-name: The Peacemaker #1
-year: 1967
+  - genre: Superhero
+  - franchise: The Peacemaker
+  - universe: DC Prime Earth
+  - character: Peacemaker (Christopher Smith)
+  - character: Peacemaker
+  - character: Fightin' 5
+  - character: The Commodore
+  - tag: silver age
+  - tag: charlton comics
+  - tag: cold war
+  - ai:rating: 2.0
+  - ai:rating_reasoning: "The Peacemaker #1 (1967) is a historically noteworthy Silver Age single issue from Charlton Comics as the first issue of Peacemaker's solo series, but the original run was commercially unsuccessful, lasting only five issues before cancellation. The character fell into obscurity for decades (per Wikipedia and DC.com retrospectives) and the series has received no award recognition. The primary historical significance lies in the character later inspiring The Comedian in Alan Moore's Watchmen. Charlton was widely regarded as a budget publisher. The issue has collector value but limited critical merit by modern standards."
+  - ai:skill_version: 7.16.4
+  - ai:engine: claude-opus-4-6


### PR DESCRIPTION
This pull request updates the metadata and descriptions for "The Peacemaker #01 (1967)" comic and its cover art in both the YAML sample and TypeScript fixtures. The changes focus on improving the accuracy, completeness, and consistency of comic issue data, including a more concise description, expanded metadata, and standardized naming.

**Metadata and Description Updates:**

- Replaced the long, detailed plot summary with a concise multi-story synopsis for "The Peacemaker #01" in both the YAML file and the TypeScript fixture (`THE_PEACEMAKER_01_1967_PARSED_YML`). The new description also mentions the Fightin' 5 backup story. [[1]](diffhunk://#diff-f12e9a5b3fc16c05350b67d43dbdbdcb9dda65603c3fbc0fc3b0eb6d12bd5ef5R1-R29) [[2]](diffhunk://#diff-d801689257daff7f7343b71bb1d47323f8de86200bb083958443d28095a5b9a7L596-R627)
- Updated the `info_url` to point to the correct comics.org page instead of the fandom wiki. [[1]](diffhunk://#diff-f12e9a5b3fc16c05350b67d43dbdbdcb9dda65603c3fbc0fc3b0eb6d12bd5ef5R1-R29) [[2]](diffhunk://#diff-d801689257daff7f7343b71bb1d47323f8de86200bb083958443d28095a5b9a7L596-R627)
- Expanded and standardized the `metadata_list` to include additional roles (e.g., editor, genre, franchise, universe, new characters, tags), and added AI-generated rating and reasoning fields for historical significance and critical merit. [[1]](diffhunk://#diff-f12e9a5b3fc16c05350b67d43dbdbdcb9dda65603c3fbc0fc3b0eb6d12bd5ef5R1-R29) [[2]](diffhunk://#diff-d801689257daff7f7343b71bb1d47323f8de86200bb083958443d28095a5b9a7L596-R627)

**Naming Consistency:**

- Standardized the comic and cover art names to "The Peacemaker #01" (instead of "The Peacemaker" or "#1") in all relevant fixture objects, improving clarity and consistency across the codebase. [[1]](diffhunk://#diff-d801689257daff7f7343b71bb1d47323f8de86200bb083958443d28095a5b9a7L665-R654) [[2]](diffhunk://#diff-d801689257daff7f7343b71bb1d47323f8de86200bb083958443d28095a5b9a7L729-R718) [[3]](diffhunk://#diff-f12e9a5b3fc16c05350b67d43dbdbdcb9dda65603c3fbc0fc3b0eb6d12bd5ef5R1-R29)

These changes ensure the test fixtures and sample data better reflect the actual comic issue, improve data quality for downstream consumers, and align naming conventions for easier maintenance.